### PR TITLE
Feat: 게시글 및 게시판 관련 엔티티 생성 및 User 엔티티와 연관관계 매핑 및 DTO, Repository, Service, Controller 파일 생성

### DIFF
--- a/src/main/java/com/est/tablelink/domain/board/domain/Board.java
+++ b/src/main/java/com/est/tablelink/domain/board/domain/Board.java
@@ -1,0 +1,33 @@
+package com.est.tablelink.domain.board.domain;
+
+import com.est.tablelink.domain.post.domain.Post;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "board")
+@Getter
+@NoArgsConstructor
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(unique = true)
+    private String name;  // 게시판 이름 (예: 자유게시판, 음식점 소개 게시판, 맛집 공유 게시판)
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
+}

--- a/src/main/java/com/est/tablelink/domain/post/controller/PostController.java
+++ b/src/main/java/com/est/tablelink/domain/post/controller/PostController.java
@@ -1,0 +1,8 @@
+package com.est.tablelink.domain.post.controller;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class PostController {
+
+}

--- a/src/main/java/com/est/tablelink/domain/post/domain/Content.java
+++ b/src/main/java/com/est/tablelink/domain/post/domain/Content.java
@@ -1,0 +1,36 @@
+package com.est.tablelink.domain.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Content {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "text")
+    @Lob
+    private String text; // 글
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;  // 게시글과 1:1 관계
+
+    @Lob
+    @Column(name = "image")
+    private byte[] image; // 이미지 데이터
+}

--- a/src/main/java/com/est/tablelink/domain/post/domain/Post.java
+++ b/src/main/java/com/est/tablelink/domain/post/domain/Post.java
@@ -1,0 +1,59 @@
+package com.est.tablelink.domain.post.domain;
+
+import com.est.tablelink.domain.board.domain.Board;
+import com.est.tablelink.domain.user.domain.User;
+import com.est.tablelink.domain.user.util.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "post")
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;  // 게시글 id
+
+    @Column(name = "title")
+    private String title; // 제목
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User author; // 작성자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board; // 게시판 id
+
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Content content; // 게시글 내용
+
+    // 작성자 검증 메서드 (삭제 권한 체크 등)
+    public boolean canModifyOrDelete(User user) {
+        return this.author.equals(user);
+    }
+
+    @Builder
+    public Post(Long id, String title, User author, Board board, Content content){
+        this.id = id;
+        this.title = title;
+        this.author = author;
+        this.board = board;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/est/tablelink/domain/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/est/tablelink/domain/post/dto/request/CreatePostRequest.java
@@ -1,0 +1,37 @@
+package com.est.tablelink.domain.post.dto.request;
+
+import com.est.tablelink.domain.board.domain.Board;
+import com.est.tablelink.domain.post.domain.Content;
+import com.est.tablelink.domain.post.domain.Post;
+import com.est.tablelink.domain.user.domain.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO for {@link com.est.tablelink.domain.post.domain.Post}
+ */
+
+@Getter
+@Setter
+@Builder
+public class CreatePostRequest {
+
+    @NotBlank(message = "제목을 작성해 주세요.")
+    @Size(max = 50, message = "제목은 50자 내로 작성해 주세요.")
+    private String title;
+
+    @NotBlank(message = "내용을 작성해 주세요.")
+    private Content content;
+
+    public Post toEntity() {
+        return Post.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/est/tablelink/domain/post/dto/response/DetailPostResponse.java
+++ b/src/main/java/com/est/tablelink/domain/post/dto/response/DetailPostResponse.java
@@ -1,0 +1,29 @@
+package com.est.tablelink.domain.post.dto.response;
+
+import com.est.tablelink.domain.post.domain.Content;
+import com.est.tablelink.domain.post.domain.Post;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class DetailPostResponse {
+    private Long id; // 게시글 id
+    private String title; // 게시글 제목
+    private String author; // 게시글 작성자 닉네임
+    private Content content; // 게시글 내용
+    private LocalDateTime createdAt; // 게시글 생성 일시
+
+    public DetailPostResponse toDto(Post post){
+        return DetailPostResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .author(post.getAuthor().getNickname())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/est/tablelink/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/est/tablelink/domain/post/repository/PostRepository.java
@@ -1,0 +1,12 @@
+package com.est.tablelink.domain.post.repository;
+
+import com.est.tablelink.domain.post.domain.Post;
+import com.est.tablelink.domain.user.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // 게시글 작성자 찾기
+    List<Post> findAllByAuthor(User user);
+}

--- a/src/main/java/com/est/tablelink/domain/post/service/PostService.java
+++ b/src/main/java/com/est/tablelink/domain/post/service/PostService.java
@@ -1,0 +1,8 @@
+package com.est.tablelink.domain.post.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostService {
+
+}

--- a/src/main/java/com/est/tablelink/domain/user/domain/User.java
+++ b/src/main/java/com/est/tablelink/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.est.tablelink.domain.user.domain;
 
+import com.est.tablelink.domain.post.domain.Post;
 import com.est.tablelink.domain.user.util.BaseEntity;
 import com.est.tablelink.domain.user.util.Role;
 import jakarta.persistence.Column;
@@ -9,16 +10,19 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.Collection;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@Table(name = "user", indexes = @Index(name = "idx_username", columnList = "username"))
 public class User extends BaseEntity {
 
     @Id
@@ -67,4 +71,8 @@ public class User extends BaseEntity {
         this.address = address;
         this.nickname = nickname;
     }
+
+    // 매핑
+    @OneToMany(mappedBy = "author")
+    public List<Post> posts = new ArrayList<>();
 }


### PR DESCRIPTION
## 💡 이슈
resolve #{이슈번호}

## 🤩 개요
- 게시글 및 게시판 관련 엔티티 생성
  - Board 엔티티: 게시글이 생성될 게시판 테이블
  - Content 엔티티: 게시글에 들어갈 내용을 저장하는 테이블
  - Post 엔티티: 게시글 테이블
- User 엔티티와 연관관계 매핑
- 게시글 관련 DTO, Repository, Service, Controller 파일 생성

## 🧑‍💻 작업 사항
- 게시글 및 게시판 관련 엔티티 생성
- User 엔티티와 연관관계 매핑
- 게시글 관련 DTO, Repository, Service, Controller 파일 생성

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?